### PR TITLE
fix(tests): drop stale v21.5.0 node_version pin from composite replay

### DIFF
--- a/tests/replays.json
+++ b/tests/replays.json
@@ -22,7 +22,6 @@
     {
       "name": "Composite action",
       "parameters": {
-        "node_version": "v21.5.0",
         "action_type": "composite"
       }
     },


### PR DESCRIPTION
The composite-replay test pinned \`node_version=v21.5.0\` (added in #7 when v20-ish was the default). After #17 bumped the default to v24 plus subsequent dep refreshes, transitive deps now require node \`^20.17.0 || >=22.9.0\`, which excludes v21 and breaks the replay's \`task init\`. Dropping the pin makes that replay use \`cookiecutter.json\`'s current default like the other three. Surfaced while opening #22 (README rewrite) — that PR will rebase on this fix.